### PR TITLE
Entity access specific callback.

### DIFF
--- a/tourney.module
+++ b/tourney.module
@@ -331,7 +331,7 @@ function tourney_entity_info() {
         ),
       ),
 
-      'access callback' => 'tourney_access',
+      'access callback' => 'tourney_entity_access',
       'module' => 'tourney',
     );
 
@@ -722,6 +722,39 @@ function tourney_access($op = 'view', $group = NULL, $account = NULL) {
         return FALSE;
       }
       $entity = entity_load_single('tourney_' . $group, $entity_id);
+      if (property_exists($entity, 'status') && $entity->status == 0) {
+        return user_access('view unpublished tourney');
+      }
+      else {
+        return user_access('access tourney');
+      }
+
+    case 'edit':
+      return user_access('edit tournament');
+
+    case 'delete':
+      return user_access('delete tournament');
+  }
+
+  return FALSE;
+}
+
+/**
+ * Entity access callback for tourney module.
+ *
+ * This is the access callback for the entity when it has not been accessed 
+ * through a menu router. I.E. a node with an entity reference field to a
+ * tournament.
+ *
+ * @see entity_access()
+ */
+function tourney_entity_access($op = 'view', $entity = NULL, $account = NULL, $entity_type = NULL) {
+  if (user_access('administer tourney')) {
+    return TRUE;
+  }
+
+  switch ($op) {
+    case 'view':
       if (property_exists($entity, 'status') && $entity->status == 0) {
         return user_access('view unpublished tourney');
       }


### PR DESCRIPTION
Old access callback will fail if not called through the menu router. I.E. in esports there are entity reference fields to tournaments.
