### PR TITLE
sort() instead of asort()

### DIFF
--- a/includes/tourney.entity.match.inc
+++ b/includes/tourney.entity.match.inc
@@ -52,7 +52,7 @@ class TourneyMatchEntity extends TourneyEntity {
         $r = relation_load($relation->rid);
         $game_ids[] = $r->endpoints[LANGUAGE_NONE][1]['entity_id'];
       }
-      asort($game_ids);
+      sort($game_ids);
       if (count($game_ids) > 0) {
         cache_set('fetchGameIds_' . $cache_id, $game_ids, 'cache_tourney');
       }


### PR DESCRIPTION
I am not sure if there was a reason for asort being used, but it caused games to be in the correct order but the keys to be off. This caused the games to not show in their proper order on some of the pre/post match pages.
### Check with Jon if there was a reason for asort
