### PR TITLE
Hardcoding in a bundle

### DIFF
--- a/modules/tourney_series/includes/tourney_series.entity.inc
+++ b/modules/tourney_series/includes/tourney_series.entity.inc
@@ -14,6 +14,8 @@ class TourneySeriesEntity extends TourneyEntity {
    */
   public function __construct($values = array(), $entityType = 'tourney_series') {
     parent::__construct($values, $entityType);
+    // @todo: Remove this hardcoded bundle.
+    $this->type = "series";
 
     if (property_exists($this, 'id') && $this->id) {
       // Add a url to the object


### PR DESCRIPTION
Entity API changed and is now requiring a bundle when the object is initially created. We need to remove this hardcode when we starting having more than one bundle.

Fixes a WSOD when adding new series'.
