### PR TITLE
Added logic to ensure contestant exists

### DIFF
--- a/includes/tourney.match.inc
+++ b/includes/tourney.match.inc
@@ -385,7 +385,9 @@ function tourney_match_form_submit($form, &$form_state) {
       }
       else {
         $contestant = $match->getContestant(1);
-        $match->queueRemoveContestant($contestant);
+        if ($contestant) {
+          $match->queueRemoveContestant($contestant);
+        }
       }
     }
     if (array_key_exists('contestant2', $form_state['input'])) {
@@ -396,7 +398,9 @@ function tourney_match_form_submit($form, &$form_state) {
       }
       else {
         $contestant = $match->getContestant(2);
-        $match->queueRemoveContestant($contestant);
+        if ($contestant) {
+          $match->queueRemoveContestant($contestant);
+        }
       }
     }
   } catch (TourneyMatchException $e) {


### PR DESCRIPTION
Added logic to ensure contestant exists

When creating a match on a tournament, it is now possible to add only one contestant at a time.
