### PR TITLE
Two new methods for series entity

### DIFF
--- a/modules/tourney_series/includes/tourney_series.entity.inc
+++ b/modules/tourney_series/includes/tourney_series.entity.inc
@@ -151,3 +151,4 @@ class TourneySeriesController {
     }
   }
 }
+


### PR DESCRIPTION
getTournamentIdArray: returns an array for all tournament ids that are on this tournament

getTournamentString: returns a comma delimited string for all tournament ids that are on this tournament
