### PR TITLE
Trim games on match save. Simplify isFinished() on match.

### DIFF
--- a/includes/tourney.entity.match.inc
+++ b/includes/tourney.entity.match.inc
@@ -513,11 +513,6 @@ class TourneyMatchEntity extends TourneyEntity {
         parent::save();
       }
 
-      // If the match is finished then trim off any extra games that are no
-      // longer required.
-      if ($this->isFinished())
-        $this->cleanGames();
-
       // Add and remove any contestants.
       if (isset($this->queue['remove_contestant'])) {
         foreach($this->queue['remove_contestant'] as $operation) {


### PR DESCRIPTION
A match will now report finished even if there is an extra game if the existing game wins will put the winner at > 50% of total games.

Currently if game 1 and game 2 are split between the teams an extra game 3 will be created. But if the setting of game 1 or game 2 was in error, and really a team has already swept the match, reseting game 2 to the correct winner does not close out the match. After this change reseting game 2 to the correct winner (via match, and then resave game 2 itself via gui) will close out the match and chop off game 3 as not needed.

Specifically lines 432 and 433 in includes/tourney.entity.match.inc needed to go away.
