### PR TITLE
fixing up manual upload file validation and saving

### DIFF
--- a/includes/tourney.entity.tournament.inc
+++ b/includes/tourney.entity.tournament.inc
@@ -497,7 +497,7 @@ class TourneyTournamentEntity extends TourneyEntity {
     parent::save();
 
     // Clear any necessary caches
-    cache_clear_all('getContestants:' . $this->eid, 'cache_tourney');
+    if (property_exists($this, 'eid')) cache_clear_all('getContestants:' . $this->eid, 'cache_tourney');
 
     // Create the matches and first game if new tournament.
     if ($new) {

--- a/includes/tourney.tournament.inc
+++ b/includes/tourney.tournament.inc
@@ -462,52 +462,56 @@ function tourney_machine_name_uniquify(&$element, &$form_state) {
 function tourney_tournament_form_submit($form, &$form_state) {
   tourney_tournament_save_contestants($form_state);
 
-  $tourney = $form_state['tourney'];
+  $tournament = $form_state['tourney'];
+
+  entity_form_submit_build_entity('tourney_tournament', $tournament, $form, $form_state);
 
   // Save settings to a config array, for use before config is actually saved
   // to the tourney table.
-  $tourney->config = array();
+  $tournament->config = array();
   foreach ($form_state['values'] as $key => $value) {
     if (substr($key, 0, 7) != 'config_') {
       continue;
     }
-    $tourney->config[substr($key, 7)] = $value;
+    $tournament->config[substr($key, 7)] = $value;
   }
-  tourney_set_plugin_options($tourney, $form_state, TRUE);
+  $tournament->config = array_merge($tournament->config, $tournament->plugin_options);
 
-  entity_form_submit_build_entity('tourney_tournament', $tourney, $form, $form_state);
+  tourney_set_plugin_options($tournament, $form_state, TRUE);
 
   // Grab the number of contestants from the plugin.
-  $controller = $tourney->format;
-  $plugin = new $controller(0, $tourney);
+  $controller = $tournament->format;
+  $plugin = new $controller(0, $tournament);
   $plugin->getPluginOptions();
+
   if (!$players = $plugin->getNumberOfPlayers()) {
     throw new Exception('Plugin returned 0 players. Tournament can not be constructed.');
   }
-  $tourney->players = $players;
+  $tournament->players = $players;
   unset($plugin);
-  tourney_tournament_save($tourney);
+
+  tourney_tournament_save($tournament);
 
   // Any fields preceded with "config_" should be saved as configuration.
   foreach ($form_state['values'] as $key => $value) {
     if (substr($key, 0, 7) != 'config_') {
       continue;
     }
-    $tourney->set(substr($key, 7), $value);
+    $tournament->set(substr($key, 7), $value);
   }
 
   // Save plugin options
-  tourney_set_plugin_options($tourney, $form_state);
+  tourney_set_plugin_options($tournament, $form_state);
 
   // Clear the ctools object cache
-  if ($tourney->config['show_round_names']) {
+  if ($tournament->config['show_round_names']) {
     $object = tourney_configure_rounds_cache_get($form_state['values']['rounds_form_id']);
-    tourney_configure_rounds_cache_set($tourney->id, $object);
+    tourney_configure_rounds_cache_set($tournament->id, $object);
     tourney_configure_rounds_cache_clear($form_state['values']['rounds_form_id']);
   }
 
   drupal_set_message(t('Your tournament has been saved.'));
-  $form_state['redirect'] = $tourney->getUri();
+  $form_state['redirect'] = $tournament->getUri();
 }
 
 /**
@@ -516,6 +520,7 @@ function tourney_tournament_form_submit($form, &$form_state) {
 function tourney_tournament_save_contestants(&$form_state) {
   $format = $form_state['values']['format'];
   $contestants = array_filter($form_state['values']['contestants']);
+  if (!$contestants) return;
   $seed_positions = &$form_state['values']['plugin_options'][$format]['seed_positions'];
 
   // Set new contestants that aren't in seed array.
@@ -720,7 +725,8 @@ function tourney_set_plugin_options(&$tourney, &$form_state, $to_cache = FALSE) 
     }
   }
 
-  if (!empty($form_state['values']['plugin_options'])) {
+  if (!empty($form_state['values']['plugin_options']) && 
+      array_key_exists('seed_positions', $form_state['values']['plugin_options'][$form_state['values']['format']])) {
     foreach ($form_state['values']['plugin_options'] as $name => $values) {
       $seed_positions = $form_state['values']['plugin_options'][$form_state['values']['format']]['seed_positions'];
       if ($to_cache == TRUE) {

--- a/plugins/tourney_formats/BaseFormatControllers/ManualUpload.php
+++ b/plugins/tourney_formats/BaseFormatControllers/ManualUpload.php
@@ -425,8 +425,6 @@ function manualupload_upload_validate(stdClass $file) {
     $errors[] = $e->getMessage();
   }
 
-  if ($report) dpm($report);
-
   return $errors;
 }
 

--- a/plugins/tourney_formats/BaseFormatControllers/SingleElimination.php
+++ b/plugins/tourney_formats/BaseFormatControllers/SingleElimination.php
@@ -79,11 +79,11 @@ class SingleEliminationController extends TourneyController {
       '#disabled' => !empty($form_state['tourney']->id) ? TRUE : FALSE,
     );
 
-    if (array_key_exists('values', $form_state)) {
+    if (array_key_exists('values', $form_state) && array_key_exists('format', $form_state['values'])) {
       $players = $form_state['values']['plugin_options'][$form_state['values']['format']]['players'] ?: $players = $form_state['tourney']->players;
       $possible = self::possibleWinners($players);
     }
-    else if (is_a($form_state['tourney'], 'TourneyTournamentEntity')) {
+    else if (is_a($form_state['tourney'], 'TourneyTournamentEntity') && property_exists($form_state['tourney'], 'players')) {
       $possible = self::possibleWinners($form_state['tourney']->players);
     }
     else {
@@ -213,6 +213,7 @@ class SingleEliminationController extends TourneyController {
   }
 
   public function buildGames() {
+    if (!$this->data['matches']) return;
     foreach ($this->data['matches'] as $id => &$match) {
       $this->data['games'][$id] = $this->buildGame(array(
         'id' => $id,


### PR DESCRIPTION
# before merge:

uploading an invalid file with throw errors when the element is validated instead of when the file is uploaded, causing the file to still save and unable to be removed
# after merge:

the CSV validation is moved to an upload validator, drupal then handles the normal saving of the file and the element validator can access the file if it successfully uploaded
