### PR TITLE
Removing the removal of the round names that was set on the lines before

### DIFF
--- a/plugins/tourney_formats/single_elim/theme/preprocess_tournament_tree_node.inc
+++ b/plugins/tourney_formats/single_elim/theme/preprocess_tournament_tree_node.inc
@@ -113,5 +113,4 @@ function template_preprocess_tourney_tournament_tree_node(&$vars) {
   $vars['parent_classes']   = implode(' ', $parent_classes);
   $vars['bye']              = $bye;
   $vars['has_children']     = $has_children;
-  $vars['round_name']       = '';
 }


### PR DESCRIPTION
On line 110 of the same file, it set round name for the tpl. The line I deleted is removing the resetting of that variable for the template file.
