### PR TITLE
Adding the created date to the series

### DIFF
--- a/includes/tourney.controller.inc
+++ b/includes/tourney.controller.inc
@@ -639,7 +639,7 @@ abstract class TourneyEntity extends Entity {
     return $this->winner;
   }
   public function save() {
-    if ($this->is_new) {
+    if ($this->is_new || $this->created == 0) {
       $this->created = time();
     }
     $this->changed = time();

--- a/modules/tourney_series/tourney_series.install
+++ b/modules/tourney_series/tourney_series.install
@@ -57,6 +57,20 @@ function tourney_series_schema() {
         'not null' => TRUE,
         'default' => 1
        ),
+      'created' => array(
+        'type' => 'int',
+        'length' => '11',
+        'default' => 0,
+        'not null' => TRUE,
+        'description' => 'The time the entity was created'
+      ),
+      "changed" => array(
+        'type' => 'int',
+        'length' => '11',
+        'default' => 0,
+        'not null' => TRUE,
+        'description' => "The time the entity was changed."
+      ),
     ),
     'primary key' => array('id'),
   );
@@ -160,4 +174,30 @@ function tourney_series_install() {
     'label' => st('Tournaments'),
   );
   field_create_instance($field_instance);
+}
+
+/**
+ * Adds fields to tourney entities
+ */
+function tourney_series_update_7001() {
+  foreach(["tourney_series"] as $key => $type) {
+    if (!db_field_exists($type, "created")) {
+      db_add_field($type, 'created', array(
+        'type' => 'int',
+        'length' => '11',
+        'default' => 0,
+        'not null' => TRUE,
+        'description' => '',
+      ));
+    }
+    if (!db_field_exists($type, "changed")) {
+      db_add_field($type, "changed", array(
+        'type' => 'int',
+        'length' => '11',
+        'default' => 0,
+        'not null' => TRUE,
+        'description' => "The time the entity was changed."
+      ));
+    }
+  }
 }


### PR DESCRIPTION
Problem: Previously there wasn't a created date for any series entities. This made the tournaments and series show up out of order if ever needed to display them in descending order.

Solution: Following the same pattern as in the tournament entities, placing the created field on the series entity.

Steps: This will require and database update. 
