### PR TITLE
Adding skip checkbox to match edit page.

### DIFF
--- a/includes/tourney.entity.match.inc
+++ b/includes/tourney.entity.match.inc
@@ -310,6 +310,13 @@ class TourneyMatchEntity extends TourneyEntity {
   }
 
   /**
+   * Retrieve property.
+   */
+  public function getSkip() {
+    return isset($this->skip) ? (bool) $this->skip : false;
+  }
+
+  /**
    * Report the entity id of the game loser.
    *
    * @return string|null
@@ -441,7 +448,7 @@ class TourneyMatchEntity extends TourneyEntity {
     // If any contestant has more than 50% wins of the maximum amount of games
     // OR the maximum amount of games has been played, then the match is
     // finished (even if its a tie).
-    if ((max($wins) > ($this->games / 2)) || (array_sum($wins) == $this->games))
+    if ((count($wins) && max($wins) > ($this->games / 2)) || (array_sum($wins) == $this->games))
       return TRUE;
 
     // Default to the match not being finished.

--- a/includes/tourney.entity.tournament.inc
+++ b/includes/tourney.entity.tournament.inc
@@ -268,6 +268,9 @@ class TourneyTournamentEntity extends TourneyEntity {
 
     if (!empty($matches)) {
       foreach($matches as $match) {
+        if ($match->getSkip()) {
+          continue;
+        }
         // Increment games win/loss.
         $games = $match->getGames();
         foreach($games as $game) {

--- a/includes/tourney.match.inc
+++ b/includes/tourney.match.inc
@@ -201,6 +201,13 @@ function tourney_match_form($form, &$form_state, $match) {
     '#default_value' => isset($match->status) ? $match->status : 0,
   );
 
+  $form['options']['skip'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Hide Stats'),
+    '#description' => 'Cause any statistics or win/loss calculations to ignore the existence of this match.',
+    '#default_value' => isset($match->skip) ? $match->skip : 0,
+  );
+
   field_attach_form('tourney_match', $match, $form, $form_state);
 
   $form['#submit'][] = 'tourney_match_form_submit';

--- a/tourney.install
+++ b/tourney.install
@@ -150,6 +150,11 @@ function tourney_schema() {
         'type' => 'int',
         'not null' => TRUE,
         'default' => 0),
+      'skip' => array(
+        'description' => 'Boolean indicating that all statistic calculations should ignore this match. Possibly a tie breaker.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'default' => 0),
       ),
     'unique keys' => array(
       'id' => array('id'),
@@ -776,6 +781,18 @@ function tourney_update_7018() {
   $result = db_query($sql);
 
   return "$num matches have been updated.";
+}
+
+/**
+ * Add a skip boolean on matches instructing all statistics calculators to ignore
+ * the presence of this match.
+ */
+function tourney_update_7019() {
+  $schema = tourney_schema();
+
+  db_add_field('tourney_match', 'skip', $schema['tourney_match']['fields']['skip']);
+
+  return "Added skip field to matches.";
 }
 
 /**


### PR DESCRIPTION
Requires a database update and cache clear. New checkbox should be present on match pages (4255 in example):

![screen shot 2015-03-11 at 5 28 10 pm](https://cloud.githubusercontent.com/assets/1635293/6609812/f7368f08-c813-11e4-8001-f42fd7cade36.png)

Checking the box will cause any calculations or win/loss accumulators to ignore this match. The standings page for that match should change depending on the value of the checkbox.