### PR TITLE
Removing double increase in game title name during the creation of a new...

### DIFF
--- a/includes/tourney.entity.match.inc
+++ b/includes/tourney.entity.match.inc
@@ -842,10 +842,11 @@ class TourneyMatchEntity extends TourneyEntity {
   public function addGame() {
     $this->cleanGames();
     $game_count = count($this->getGameIds());
+    $game_count++;
     $game = new TourneyGameEntity(array(
       'type'  => $this->getTournament()->get('game_bundle', 'game'),
-      'title' => 'Game ' . ++$game_count,
-      'name'  => $this->name . '_game-' . ++$game_count,
+      'title' => 'Game ' . $game_count,
+      'name'  => $this->name . '_game-' . $game_count,
     ));
     $game->save();
     // Add the relationship to the game.


### PR DESCRIPTION
... game.

Create a new test tournament, single elimination with 2 contestants (3 games each match). Check the tourney_game table, there should only be 1 game. After playing the first game a second game should be created in the table as game-2 (instead of game-3).