### PR TITLE
Placing a try catch to remove pdo errors of games trying to be created twice

### DIFF
--- a/tourney.rules.inc
+++ b/tourney.rules.inc
@@ -181,8 +181,13 @@ function tourney_action_game_is_won($match, $quotient) {
 
     // If all our games are played and won, then we'll need to make a new game to continue the match
     if ($match->checkGames() == TRUE) {
-      $game = $match->addGame();    
-      $message = t("A new game has been created for {$game->title}.");
+      try {
+        $game = $match->addGame();
+        $message = t("A new game has been created! for {$game->title}.");
+      }
+      catch (TourneyMatchException $e) {
+        // Do nothing, just let the exception write to watchdog.
+      }
     }
     else {
       $message = t('Game updated, but not all games have a winner selected. Action not completed.');


### PR DESCRIPTION
**Issue**
Ran into instances where the game would try to be added twice resulting in an "Unexpected error has occured" PDO error. 

**Fix**
Adding a try/catch to assure that the PDO error doesn't interfere with the user's experience and throw an unexpected error as the game does get saved anyway.